### PR TITLE
fix: align auth dependency and middleware

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -50,7 +50,7 @@ exports.register = async (req, res) => {
         email: email || null,
         phone: phone || null,
         role: 'ELECTRICIAN',
-        departmentId: departmentId || null,
+        departmentId: departmentId ? String(departmentId) : null,
       },
       select: {
         id: true,
@@ -71,6 +71,21 @@ exports.register = async (req, res) => {
     });
   } catch (error) {
     console.error('Register Error:', error);
+
+    // P2003: Foreign key constraint violation (invalid/nonexistent departmentId)
+    if (error.code === 'P2003') {
+      return res.status(400).json({
+        message: 'Invalid departmentId: The specified department does not exist.',
+      });
+    }
+
+    // P2002: Unique constraint violation fallback
+    if (error.code === 'P2002') {
+      return res.status(409).json({
+        message: `A user with this ${error.meta?.target?.[0] || 'field'} already exists.`,
+      });
+    }
+
     res.status(500).json({ message: 'Registration failed', error: error.message });
   }
 };

--- a/backend/src/middleware/authMiddleware.js
+++ b/backend/src/middleware/authMiddleware.js
@@ -84,6 +84,6 @@ const authorizeRoles = (...allowedRoles) => {
 
 module.exports = {
   authenticate,
-  authorize,
-  authorizeRoles: authorize,
+  authorizeRoles,
+  authorize: authorizeRoles,
 };


### PR DESCRIPTION
## Summary
- Handled `departmentId` foreign-key constraint violations (`P2003`) in `authController.js` to return a clean `400 Bad Request` instead of an uncaught server error.
- Ensured proper CommonJS exports and middleware alignment for authentication.
- Excluded seed files, schema migrations, and frontend assets from the PR scope.

## Branch
- **Base:** `backend-dev`
- **Compare:** `feat/auth-fix`