### PR TITLE
fix(security): add JWT_SECRET startup guard

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,7 +1,20 @@
-const jobRoutes = require('./routes/jobRoutes');
+
+require('dotenv').config();
+
+// Startup Guard: Validate critical environment variables before bootstrapping
+const REQUIRED_ENV_VARS = ['JWT_SECRET'];
+
+for (const envVar of REQUIRED_ENV_VARS) {
+  if (!process.env[envVar] || process.env[envVar].trim() === '') {
+    console.error(`\x1b[31m[FATAL ERROR] Missing required environment variable: ${envVar}\x1b[0m`);
+    console.error(`Please set ${envVar} in your .env file before starting the server.`);
+    process.exit(1);
+  }
+}
+
 const express = require('express');
 const cors = require('cors');
-require('dotenv').config();
+const jobRoutes = require('./routes/jobRoutes');
 const complaintRoutes = require('./routes/complaintRoutes');
 const healthRoutes = require('./routes/healthRoutes');
 const complaintStatusRoutes = require('./routes/complaintStatusRoutes');


### PR DESCRIPTION
## Summary
- Added a fail-fast validation check in `server.js` before `app.listen()`.
- The server now verifies that `JWT_SECRET` is defined and non-empty at boot time. If missing, it logs a fatal error and terminates immediately with `process.exit(1)`. 
- This prevents the application from starting insecurely or signing tokens with undefined secrets.

## Branch Details
- **Base Branch:** `backend-dev`
- **Compare Branch:** `feat/auth-fix`

## Testing Performed
- Removed `JWT_SECRET` from `.env` and verified the server crashes immediately with the expected fatal error.
- Restored `JWT_SECRET` and verified the server boots normally.